### PR TITLE
Add utf-8 encoding metadata to the file

### DIFF
--- a/lib/puppet/face/ls.rb
+++ b/lib/puppet/face/ls.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'puppet/face'
 
 Puppet::Face.define(:ls, '0.0.1') do


### PR DESCRIPTION
This file contains utf-8 characters.  When running with ruby 1.9,
a bit of metadata is needed to avoid a crash.

Without this, "puppet ls" will abort with:

```
# puppet ls foo
Error: Could not parse application options: invalid byte sequence in US-ASCII
```
