### PR TITLE
"puppet ls" exits with "Error: undefined method `split' for nil:NilClass" for some paths

### DIFF
--- a/lib/puppet/face/ls.rb
+++ b/lib/puppet/face/ls.rb
@@ -35,6 +35,7 @@ Puppet::Face.define(:ls, '0.0.1') do
         filepath = (file[:path] || file.title)
         rel_path = filepath[path.length + 1 .. - 1]
         if not options[:recursive]
+          next if rel_path.nil?
           next if rel_path.split(File::SEPARATOR).length > 1
         end
         if filepath.start_with? path


### PR DESCRIPTION
"rel_path" seems to be "nil" for some reason.

If it is nil, it seems safer to skip to next file in list, and not try to do a split.

before change:

```
# puppet ls /etc/systemd/system
Error: undefined method `split' for nil:NilClass
Error: Try 'puppet help ls list' for usage

# puppet ls /etc/systemd/system -r
nagios-nrpe-server.service
  declared in /srv/puppet/env/production/legacy-modules/site/systemd/manifests/unit.pp:15
  content from a "content" parameter
```

after change:

```
# puppet ls /etc/systemd/system -r
nagios-nrpe-server.service
  declared in /srv/puppet/env/production/legacy-modules/site/systemd/manifests/unit.pp:15
  content from a "content" parameter
# puppet ls /etc/systemd/system
nagios-nrpe-server.service
  declared in /srv/puppet/env/production/legacy-modules/site/systemd/manifests/unit.pp:15
  content from a "content" parameter
```

The content of  "puppet ls / -r" is the same before and after.
