### PR TITLE
Don't skip a full match if recursive is not set

### DIFF
--- a/lib/puppet/face/ls.rb
+++ b/lib/puppet/face/ls.rb
@@ -36,7 +36,7 @@ Puppet::Face.define(:ls, '0.0.1') do
       end.each do |file|
         filepath = (file[:path] || file.title)
         rel_path = filepath[path.length + 1 .. - 1]
-        if not options[:recursive]
+        if not options[:recursive] and not filepath.eql? path
           next if rel_path.nil?
           next if rel_path.split(File::SEPARATOR).length > 1
         end


### PR DESCRIPTION
puppet ls would decide it needed the -r flag if provided with a
full path to a file that in fact does get managed by puppet. Extra check
if maybe we can match the full path before bailing out without -r.
Fixes #4